### PR TITLE
Fix retry import bug and resolve all linter issues

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,23 +1,28 @@
+// Package config предоставляет управление конфигурацией с использованием Viper.
 package config
 
 import (
 	"github.com/spf13/viper"
 )
 
+// Config оборачивает экземпляр конфигурации Viper.
 type Config struct {
 	v *viper.Viper
 }
 
+// New создает новый экземпляр Config.
 func New() *Config {
 	v := viper.New()
 	return &Config{v: v}
 }
 
+// Load читает конфигурацию из указанного файла.
 func (c *Config) Load(path string) error {
 	c.v.SetConfigFile(path)
 	return c.v.ReadInConfig()
 }
 
+// GetString получает строковое значение из конфигурации по ключу.
 func (c *Config) GetString(key string) string {
 	return c.v.GetString(key)
 }

--- a/dbpg/dbpg.go
+++ b/dbpg/dbpg.go
@@ -1,3 +1,4 @@
+// Package dbpg предоставляет управление подключениями к PostgreSQL с поддержкой master-slave.
 package dbpg
 
 import (
@@ -5,16 +6,17 @@ import (
 	"database/sql"
 	"time"
 
+	_ "github.com/lib/pq" // Драйвер PostgreSQL.
 	"github.com/wb-go/wbf/retry"
-
-	_ "github.com/lib/pq"
 )
 
+// DB представляет подключение к базе данных с master и slave узлами.
 type DB struct {
 	Master *sql.DB
 	Slaves []*sql.DB
 }
 
+// Options содержит опции конфигурации подключения к базе данных.
 type Options struct {
 	MaxOpenConns    int
 	MaxIdleConns    int
@@ -36,13 +38,16 @@ func applyOptions(db *sql.DB, opts *Options) {
 	}
 }
 
+// New создает новый экземпляр DB с master и slave подключениями.
 func New(masterDSN string, slaveDSNs []string, opts *Options) (*DB, error) {
 	master, err := sql.Open("postgres", masterDSN)
 	if err != nil {
 		return nil, err
 	}
 	applyOptions(master, opts)
-	var slaves []*sql.DB
+
+	// Предварительно выделяем память для лучшей производительности.
+	slaves := make([]*sql.DB, 0, len(slaveDSNs))
 	for _, dsn := range slaveDSNs {
 		slave, err := sql.Open("postgres", dsn)
 		if err != nil {
@@ -54,19 +59,27 @@ func New(masterDSN string, slaveDSNs []string, opts *Options) (*DB, error) {
 	return &DB{Master: master, Slaves: slaves}, nil
 }
 
+// QueryContext выполняет запрос на slave если доступен, иначе на master.
 func (db *DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	if len(db.Slaves) > 0 {
-		// Простейший round-robin
+		// Простейший round-robin.
 		return db.Slaves[0].QueryContext(ctx, query, args...)
 	}
 	return db.Master.QueryContext(ctx, query, args...)
 }
 
+// ExecContext выполняет команду на master базе данных.
 func (db *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	return db.Master.ExecContext(ctx, query, args...)
 }
 
-func (db *DB) ExecWithRetry(ctx context.Context, strat retry.Strategy, query string, args ...interface{}) (sql.Result, error) {
+// ExecWithRetry выполняет команду с стратегией повторных попыток.
+func (db *DB) ExecWithRetry(
+	ctx context.Context,
+	strategy retry.Strategy,
+	query string,
+	args ...interface{},
+) (sql.Result, error) {
 	var res sql.Result
 	err := retry.Do(func() error {
 		r, e := db.ExecContext(ctx, query, args...)
@@ -74,22 +87,36 @@ func (db *DB) ExecWithRetry(ctx context.Context, strat retry.Strategy, query str
 			res = r
 		}
 		return e
-	}, strat)
+	}, strategy)
 	return res, err
 }
 
-func (db *DB) QueryWithRetry(ctx context.Context, strat retry.Strategy, query string, args ...interface{}) (*sql.Rows, error) {
+// QueryWithRetry выполняет запрос с стратегией повторных попыток.
+func (db *DB) QueryWithRetry(
+	ctx context.Context,
+	strategy retry.Strategy,
+	query string,
+	args ...interface{},
+) (*sql.Rows, error) {
 	var rows *sql.Rows
 	err := retry.Do(func() error {
 		r, e := db.QueryContext(ctx, query, args...)
 		if e == nil {
+			if rowsErr := r.Err(); rowsErr != nil {
+				defer func() {
+					_ = r.Close()
+				}()
+				return rowsErr
+			}
 			rows = r
 		}
 		return e
-	}, strat)
+	}, strategy)
+
 	return rows, err
 }
 
+// BatchExec выполняет несколько запросов пакетно асинхронно.
 func (db *DB) BatchExec(ctx context.Context, in <-chan string) {
 	go func() {
 		for query := range in {

--- a/dbpg/dbpg.go
+++ b/dbpg/dbpg.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"time"
 
-	"wbf/retry"
+	"github.com/wb-go/wbf/retry"
 
 	_ "github.com/lib/pq"
 )

--- a/ginext/ginext.go
+++ b/ginext/ginext.go
@@ -1,23 +1,29 @@
+// Package ginext предоставляет расширения для веб-фреймворка Gin.
 package ginext
 
 import (
 	"github.com/gin-gonic/gin"
 )
 
+// Engine расширяет стандартный Gin Engine.
 type Engine struct {
 	*gin.Engine
 }
 
+// Context представляет контекст HTTP запроса.
 type Context = gin.Context
 
+// New создает новый экземпляр Engine.
 func New() *Engine {
 	return &Engine{gin.New()}
 }
 
+// GET регистрирует GET маршрут.
 func (e *Engine) GET(relativePath string, handlers ...gin.HandlerFunc) {
 	e.Engine.GET(relativePath, handlers...)
 }
 
+// Run запускает HTTP сервер на указанном адресе.
 func (e *Engine) Run(addr ...string) error {
 	return e.Engine.Run(addr...)
 }

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"context"
 
-	"wbf/retry"
+	"github.com/wb-go/wbf/retry"
 
 	"github.com/segmentio/kafka-go"
 )

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -1,21 +1,24 @@
+// Package kafka предоставляет клиенты для работы с Apache Kafka.
 package kafka
 
 import (
 	"context"
 
-	"github.com/wb-go/wbf/retry"
-
 	"github.com/segmentio/kafka-go"
+	"github.com/wb-go/wbf/retry"
 )
 
+// Producer представляет Kafka продюсер.
 type Producer struct {
 	Writer *kafka.Writer
 }
 
+// Consumer представляет Kafka консьюмер.
 type Consumer struct {
 	Reader *kafka.Reader
 }
 
+// NewProducer создает новый Kafka продюсер.
 func NewProducer(brokers []string, topic string) *Producer {
 	return &Producer{
 		Writer: &kafka.Writer{
@@ -26,6 +29,7 @@ func NewProducer(brokers []string, topic string) *Producer {
 	}
 }
 
+// Send отправляет сообщение в Kafka.
 func (p *Producer) Send(ctx context.Context, key, value []byte) error {
 	return p.Writer.WriteMessages(ctx, kafka.Message{
 		Key:   key,
@@ -33,16 +37,19 @@ func (p *Producer) Send(ctx context.Context, key, value []byte) error {
 	})
 }
 
+// Close закрывает соединение с Kafka.
 func (p *Producer) Close() error {
 	return p.Writer.Close()
 }
 
-func (p *Producer) SendWithRetry(ctx context.Context, strat retry.Strategy, key, value []byte) error {
+// SendWithRetry отправляет сообщение с стратегией повторных попыток.
+func (p *Producer) SendWithRetry(ctx context.Context, strategy retry.Strategy, key, value []byte) error {
 	return retry.Do(func() error {
 		return p.Send(ctx, key, value)
-	}, strat)
+	}, strategy)
 }
 
+// NewConsumer создает новый Kafka консьюмер.
 func NewConsumer(brokers []string, topic, groupID string) *Consumer {
 	return &Consumer{
 		Reader: kafka.NewReader(kafka.ReaderConfig{
@@ -53,19 +60,23 @@ func NewConsumer(brokers []string, topic, groupID string) *Consumer {
 	}
 }
 
+// Fetch получает сообщение из Kafka.
 func (c *Consumer) Fetch(ctx context.Context) (kafka.Message, error) {
 	return c.Reader.FetchMessage(ctx)
 }
 
+// Commit подтверждает обработку сообщения.
 func (c *Consumer) Commit(ctx context.Context, msg kafka.Message) error {
 	return c.Reader.CommitMessages(ctx, msg)
 }
 
+// Close закрывает соединение с Kafka.
 func (c *Consumer) Close() error {
 	return c.Reader.Close()
 }
 
-func (c *Consumer) FetchWithRetry(ctx context.Context, strat retry.Strategy) (kafka.Message, error) {
+// FetchWithRetry получает сообщение с стратегией повторных попыток.
+func (c *Consumer) FetchWithRetry(ctx context.Context, strategy retry.Strategy) (kafka.Message, error) {
 	var msg kafka.Message
 	err := retry.Do(func() error {
 		m, e := c.Fetch(ctx)
@@ -73,15 +84,16 @@ func (c *Consumer) FetchWithRetry(ctx context.Context, strat retry.Strategy) (ka
 			msg = m
 		}
 		return e
-	}, strat)
+	}, strategy)
 	return msg, err
 }
 
-func (c *Consumer) StartConsuming(ctx context.Context, out chan<- kafka.Message, strat retry.Strategy) {
+// StartConsuming запускает процесс потребления сообщений.
+func (c *Consumer) StartConsuming(ctx context.Context, out chan<- kafka.Message, strategy retry.Strategy) {
 	go func() {
 		defer close(out)
 		for {
-			msg, err := c.FetchWithRetry(ctx, strat)
+			msg, err := c.FetchWithRetry(ctx, strategy)
 			if err != nil {
 				// Можно добавить логирование ошибки
 				break

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,17 +1,19 @@
+// Package redis предоставляет клиент для работы с Redis.
 package redis
 
 import (
 	"context"
 
-	"github.com/wb-go/wbf/retry"
-
 	"github.com/go-redis/redis/v8"
+	"github.com/wb-go/wbf/retry"
 )
 
+// Client оборачивает Redis клиент.
 type Client struct {
 	*redis.Client
 }
 
+// New создает новый Redis клиент.
 func New(addr, password string, db int) *Client {
 	return &Client{
 		redis.NewClient(&redis.Options{
@@ -22,15 +24,18 @@ func New(addr, password string, db int) *Client {
 	}
 }
 
+// Get получает значение по ключу из Redis.
 func (c *Client) Get(ctx context.Context, key string) (string, error) {
 	return c.Client.Get(ctx, key).Result()
 }
 
+// Set устанавливает значение по ключу в Redis.
 func (c *Client) Set(ctx context.Context, key string, value interface{}) error {
 	return c.Client.Set(ctx, key, value, 0).Err()
 }
 
-func (c *Client) GetWithRetry(ctx context.Context, strat retry.Strategy, key string) (string, error) {
+// GetWithRetry получает значение с стратегией повторных попыток.
+func (c *Client) GetWithRetry(ctx context.Context, strategy retry.Strategy, key string) (string, error) {
 	var val string
 	err := retry.Do(func() error {
 		v, e := c.Get(ctx, key)
@@ -38,20 +43,22 @@ func (c *Client) GetWithRetry(ctx context.Context, strat retry.Strategy, key str
 			val = v
 		}
 		return e
-	}, strat)
+	}, strategy)
 	return val, err
 }
 
-func (c *Client) SetWithRetry(ctx context.Context, strat retry.Strategy, key string, value interface{}) error {
+// SetWithRetry устанавливает значение с стратегией повторных попыток.
+func (c *Client) SetWithRetry(ctx context.Context, strategy retry.Strategy, key string, value interface{}) error {
 	return retry.Do(func() error {
 		return c.Set(ctx, key, value)
-	}, strat)
+	}, strategy)
 }
 
+// BatchWriter выполняет пакетную запись в Redis.
 func (c *Client) BatchWriter(ctx context.Context, in <-chan [2]string) {
 	go func() {
 		for pair := range in {
-			_ = c.Set(ctx, pair[0], pair[1]) // Ошибки можно логировать
+			_ = c.Set(ctx, pair[0], pair[1]) // Ошибки можно логировать.
 			select {
 			case <-ctx.Done():
 				return

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"context"
 
-	"wbf/retry"
+	"github.com/wb-go/wbf/retry"
 
 	"github.com/go-redis/redis/v8"
 )

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,25 +1,28 @@
+// Package retry предоставляет функциональность повторных попыток с настраиваемыми стратегиями.
 package retry
 
 import (
 	"time"
 )
 
+// Strategy определяет параметры поведения повторных попыток.
 type Strategy struct {
-	Attempts int
-	Delay    time.Duration
-	Backoff  float64 // множитель для увеличения задержки
+	Attempts int           // Количество попыток.
+	Delay    time.Duration // Начальная задержка между попытками.
+	Backoff  float64       // Множитель для увеличения задержки.
 }
 
-func Do(fn func() error, strat Strategy) error {
-	delay := strat.Delay
+// Do выполняет функцию с заданной стратегией повторных попыток.
+func Do(fn func() error, strategy Strategy) error {
+	delay := strategy.Delay
 	var err error
-	for i := 0; i < strat.Attempts; i++ {
+	for i := 0; i < strategy.Attempts; i++ {
 		err = fn()
 		if err == nil {
 			return nil
 		}
 		time.Sleep(delay)
-		delay = time.Duration(float64(delay) * strat.Backoff)
+		delay = time.Duration(float64(delay) * strategy.Backoff)
 	}
 	return err
 }

--- a/zlog/zlog.go
+++ b/zlog/zlog.go
@@ -1,3 +1,4 @@
+// Package zlog предоставляет логирование с использованием Zerolog.
 package zlog
 
 import (
@@ -6,8 +7,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Logger глобальный экземпляр логгера.
 var Logger zerolog.Logger
 
+// Init инициализирует глобальный логгер.
 func Init() {
 	Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
 }


### PR DESCRIPTION
## Что исправлено
-  Исправлены пути импортов с `wbf/retry` на `github.com/wb-go/wbf/retry`
-  Устранены все ошибки линтера (golangci-lint теперь проходит)
-  Добавлены godoc комментарии ко всем экспортируемым функциям и типам