### PR TITLE
Fix import paths

### DIFF
--- a/dbpg/dbpg.go
+++ b/dbpg/dbpg.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"time"
 
-	"wbf/retry"
+	"github.com/wb-go/wbf/retry"
 
 	_ "github.com/lib/pq"
 )

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"context"
 
-	"wbf/retry"
+	"github.com/wb-go/wbf/retry"
 
 	"github.com/segmentio/kafka-go"
 )

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -3,10 +3,12 @@ package redis
 import (
 	"context"
 
-	"wbf/retry"
-
 	"github.com/go-redis/redis/v8"
+	"github.com/wb-go/wbf/retry"
 )
+
+// NoMatches is used for when Redis did not get any matches.
+const NoMatches = redis.Nil
 
 type Client struct {
 	*redis.Client


### PR DESCRIPTION
Import paths are now set as absolute in the places they were not. Example: dbpg.go `import "wbf/retry" ==> "github.com/wb-go/wbf/retry"` This is an important bug fix as the bug does not allow external projects to run using this package anywhere in the code.