### PR TITLE
feat(dbpg): add QueryRowContext method and implement round-robin for slave queries

### DIFF
--- a/dbpg/balancer.go
+++ b/dbpg/balancer.go
@@ -1,0 +1,32 @@
+package dbpg
+
+import "sync"
+
+type balancer struct {
+	idx int
+	max int // Кол-во slaves
+
+	mu *sync.Mutex
+}
+
+func newBalancer(max int) *balancer {
+	return &balancer{
+		idx: 0,
+		max: max,
+		mu:  new(sync.Mutex),
+	}
+}
+
+func (b *balancer) index() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.max <= 0 {
+		return 0
+	}
+
+	res := b.idx
+	b.idx = (b.idx + 1) % b.max
+	
+	return res
+}

--- a/dbpg/dbpg.go
+++ b/dbpg/dbpg.go
@@ -4,7 +4,6 @@ package dbpg
 import (
 	"context"
 	"database/sql"
-	"sync"
 	"time"
 
 	_ "github.com/lib/pq" // Драйвер PostgreSQL.
@@ -13,10 +12,10 @@ import (
 
 // DB представляет подключение к базе данных с master и slave узлами.
 type DB struct {
-	Master  *sql.DB
-	Slaves  []*sql.DB
-	rrIndex int // индекс для round-robin
-	rrMutex sync.Mutex
+	balancer *balancer
+
+	Master *sql.DB
+	Slaves []*sql.DB
 }
 
 // Options содержит опции конфигурации подключения к базе данных.
@@ -59,7 +58,11 @@ func New(masterDSN string, slaveDSNs []string, opts *Options) (*DB, error) {
 		applyOptions(slave, opts)
 		slaves = append(slaves, slave)
 	}
-	return &DB{Master: master, Slaves: slaves}, nil
+
+	// Создаем balancer.
+	balancer := newBalancer(len(slaveDSNs))
+
+	return &DB{Master: master, Slaves: slaves, balancer: balancer}, nil
 }
 
 // QueryContext выполняет запрос на slave если доступен, иначе на master.
@@ -120,6 +123,23 @@ func (db *DB) QueryWithRetry(
 	return rows, err
 }
 
+// QueryRowWithRetry выполняет запрос с стратегией повторных попыток.
+func (db *DB) QueryRowWithRetry(
+	ctx context.Context,
+	strategy retry.Strategy,
+	query string,
+	args ...interface{},
+) (*sql.Row, error) {
+	var row *sql.Row
+	err := retry.Do(func() error {
+		r := db.QueryRowContext(ctx, query, args...)
+		row = r
+		return r.Err()
+	}, strategy)
+
+	return row, err
+}
+
 // BatchExec выполняет несколько запросов пакетно асинхронно.
 func (db *DB) BatchExec(ctx context.Context, in <-chan string) {
 	go func() {
@@ -137,13 +157,8 @@ func (db *DB) BatchExec(ctx context.Context, in <-chan string) {
 // selectDB возвращает базу для выполнения запроса: slave (round-robin) или master.
 func (db *DB) selectDB() *sql.DB {
 	if len(db.Slaves) > 0 {
-		// Выбираем slave по индексу rrIndex и обновляем индекс для следующего запроса.
-		db.rrMutex.Lock()
-		slave := db.Slaves[db.rrIndex]
-		db.rrIndex = (db.rrIndex + 1) % len(db.Slaves) // round-robin по кругу
-		db.rrMutex.Unlock()
-
-		return slave
+		// Выбираем slave при помощи balancer.
+		return db.Slaves[db.balancer.index()]
 	}
 
 	return db.Master


### PR DESCRIPTION
Implemented proper round-robin for multiple slave connections in dbpg.DB

- QueryContext now distributes read queries across all available slaves.
- Added rrIndex with mutex to safely handle concurrent requests.
- If no slaves are configured, queries go to master as before.